### PR TITLE
[TYPO] Change method name

### DIFF
--- a/clover.xml
+++ b/clover.xml
@@ -488,7 +488,7 @@
         <line num="345" type="stmt" count="2"/>
         <line num="346" type="stmt" count="2"/>
         <line num="348" type="stmt" count="8"/>
-        <line num="356" type="method" name="synchronizedModifications" crap="2" count="7"/>
+        <line num="356" type="method" name="synchronizeModifications" crap="2" count="7"/>
         <line num="358" type="stmt" count="7"/>
         <line num="359" type="stmt" count="1"/>
         <line num="361" type="stmt" count="6"/>

--- a/example/app/Http/Controllers/VisitorController.php
+++ b/example/app/Http/Controllers/VisitorController.php
@@ -34,7 +34,7 @@ class VisitorController extends Controller
             ]);
             $visitor = Flagship::newVisitor($data['visitor_id'], $data['context']);
 
-            $visitor->synchronizedModifications();
+            $visitor->synchronizeModifications();
 
             $request->session()->put('visitor', $visitor);
             return response()->json($visitor->getModifications());
@@ -56,7 +56,7 @@ class VisitorController extends Controller
 
             $visitor->updateContext($key, $value);
 
-            $visitor->synchronizedModifications();
+            $visitor->synchronizeModifications();
 
             return response()->json($visitor);
         } catch (ValidationException $exception) {

--- a/example/app/Http/Middleware/FlagshipVisitor.php
+++ b/example/app/Http/Middleware/FlagshipVisitor.php
@@ -23,7 +23,7 @@ class FlagshipVisitor
             Log::error('Flagship', $message);
             return response()->json($message, 422);
         }
-//        $visitor->synchronizedModifications();
+//        $visitor->synchronizeModifications();
         app()->instance(Visitor::class, $visitor);
         return $next($request);
     }

--- a/src/Visitor.php
+++ b/src/Visitor.php
@@ -353,7 +353,7 @@ class Visitor implements JsonSerializable
      * from the server according to the visitor context.
      * @return void
      */
-    public function synchronizedModifications()
+    public function synchronizeModifications()
     {
         if (!$this->hasDecisionManager(FlagshipConstant::TAG_SYNCHRONIZED_MODIFICATION)) {
             return;

--- a/tests/VisitorTest.php
+++ b/tests/VisitorTest.php
@@ -254,7 +254,7 @@ class VisitorTest extends TestCase
      * @dataProvider modifications
      * @param Modification[] $modifications
      */
-    public function testSynchronizedModifications($modifications)
+    public function testSynchronizeModifications($modifications)
     {
 
         $apiManagerStub = $this->getMockForAbstractClass(
@@ -276,7 +276,7 @@ class VisitorTest extends TestCase
 
         $visitor = new Visitor($configManager, "visitorId", []);
 
-        $visitor->synchronizedModifications();
+        $visitor->synchronizeModifications();
 
         $this->assertSame($modifications, $visitor->getModifications());
 
@@ -369,7 +369,7 @@ class VisitorTest extends TestCase
      * @dataProvider modifications
      * @param Modification[] $modifications
      */
-    public function testSynchronizedModificationsWithoutDecisionManager($modifications)
+    public function testSynchronizeModificationsWithoutDecisionManager($modifications)
     {
         $logManagerStub = $this->getMockForAbstractClass(
             'Psr\Log\LoggerInterface',
@@ -395,7 +395,7 @@ class VisitorTest extends TestCase
                 [FlagshipConstant::TAG => FlagshipConstant::TAG_SYNCHRONIZED_MODIFICATION]
             );
 
-        $visitor->synchronizedModifications();
+        $visitor->synchronizeModifications();
     }
 
     /**
@@ -425,7 +425,7 @@ class VisitorTest extends TestCase
             ->setMethods(['logError'])
             ->setConstructorArgs([$configManager, "visitorId", []])->getMock();
 
-        $visitorMock->synchronizedModifications();
+        $visitorMock->synchronizeModifications();
 
         //Test getModification key is null
         //Return DefaultValue
@@ -527,7 +527,7 @@ class VisitorTest extends TestCase
 
         $visitor = new Visitor($configManager, "visitorId", []);
 
-        $visitor->synchronizedModifications();
+        $visitor->synchronizeModifications();
 
         $modification = $modifications[0];
 
@@ -622,7 +622,7 @@ class VisitorTest extends TestCase
             ->method('sendActive')
             ->with($visitor, $modifications[0]);
 
-        $visitor->synchronizedModifications();
+        $visitor->synchronizeModifications();
 
         $visitor->activateModification($modifications[0]->getKey());
 
@@ -686,7 +686,7 @@ class VisitorTest extends TestCase
 
         $visitor = new Visitor($configManager, "visitorId", []);
 
-        $visitor->synchronizedModifications();
+        $visitor->synchronizeModifications();
 
         $flagshipSdk = FlagshipConstant::FLAGSHIP_SDK;
 
@@ -753,7 +753,7 @@ class VisitorTest extends TestCase
             ->method('sendActive')
             ->with($visitor, $modifications[0]);
 
-        $visitor->synchronizedModifications();
+        $visitor->synchronizeModifications();
 
         $visitor->getModification($modifications[0]->getKey(), 'defaultValue', true);
     }


### PR DESCRIPTION
Referring to Issue #39 
Typo : synchronizedModifications
Fixed : synchronizeModifications

Changing all mention of synchronizedModifications method following a typo (#39)